### PR TITLE
Adds severity level

### DIFF
--- a/olivertwist/config/model.py
+++ b/olivertwist/config/model.py
@@ -7,15 +7,22 @@ Created 23. Dec 2020 13:40
 """
 
 from dataclasses import dataclass
-from typing import List
+from enum import Enum
+from typing import Optional, List
 
 from dataclasses_jsonschema import JsonSchemaMixin
+
+
+class Severity(Enum):
+    WARNING = "warning"
+    ERROR = "error"
 
 
 @dataclass
 class RuleConfig(JsonSchemaMixin):
     id: str
     enabled: bool
+    severity: Optional[Severity] = Severity.ERROR
 
 
 @dataclass
@@ -24,3 +31,10 @@ class Config(JsonSchemaMixin):
 
     def get_disabled_rule_ids(self) -> List[str]:
         return [r.id for r in self.universal if r.enabled is False]
+
+    def get_config_for_rule_id(self, rule_id: str) -> RuleConfig:
+        for rule_config in self.universal:
+            if rule_config.id == rule_id:
+                return rule_config
+
+        return None

--- a/olivertwist/main.py
+++ b/olivertwist/main.py
@@ -94,12 +94,11 @@ def format_for_terminal(results: List[Result]):
 
 
 def get_colour(result: Result):
-    colour = "green"
     if result.has_errors:
-        colour = "red"
-    if result.has_warnings:
-        colour = "yellow"
-    return colour
+        return "red"
+    elif result.has_warnings:
+        return "yellow"
+    return "green"
 
 
 def exit_message(results: List[Result]):

--- a/olivertwist/reporter/model.py
+++ b/olivertwist/reporter/model.py
@@ -14,6 +14,7 @@ class ReportStatus(str, Enum):
     PASSED = "passed"
     SKIPPED = "skipped"
     ERRORED = "errored"
+    WARNED = "warned"
 
 
 @dataclass
@@ -48,10 +49,12 @@ class ReportSummary:
         passed: int,
         skipped: int,
         errored: int,
+        warned: int,
     ) -> None:
         self.passed = passed
         self.skipped = skipped
         self.errored = errored
+        self.warned = warned
 
 
 @dataclass

--- a/olivertwist/reporter/templates/macros.jinja
+++ b/olivertwist/reporter/templates/macros.jinja
@@ -6,6 +6,9 @@
     <li class="list-inline-item">
         {{ status('errored') }} Errored: {{ summary.errored }}
     </li>
+     <li class="list-inline-item">
+        {{ status('warned') }} Warned: {{ summary.warned }}
+    </li>
 </ul>
 {% endmacro %}
 
@@ -19,5 +22,8 @@
     {% endif %}
     {% if status == 'errored' %} 
         <p><i class="fas fa-times text-danger"></i>
+    {% endif %}
+    {% if status == 'warned' %} 
+        <p><i class="fas fa-exclamation-triangle text-warning"></i>
     {% endif %}
 {% endmacro %}

--- a/olivertwist/reporter/terminal.py
+++ b/olivertwist/reporter/terminal.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Document terminal here.
+
+Copyright (C) 2021, Auto Trader UK
+Created 13. Jan 2021 20:44
+
+"""
+from typing import List
+
+import click
+
+from olivertwist.ruleengine.result import Result
+
+
+def get_colour(result: Result):
+    colour = "green"
+    if result.has_errors:
+        colour = "red"
+    if result.has_warnings:
+        colour = "yellow"
+    return colour
+
+
+def report_to_terminal(results: List[Result]):
+    for result in results:
+        colour = get_colour(result)
+        name = click.style(f"{result.rule.name}:", fg=colour)
+        link = click.style(
+            f"https://github.com/autotraderuk/oliver-twist/blob/main/RULES.md#{result.rule.id}",
+            fg="blue",
+        )
+        click.echo(f"{name} [{link}]:")
+        for node in result.failures:
+            click.secho(f" - {node.id}", fg=colour)
+
+        click.echo()

--- a/olivertwist/ruleengine/engine.py
+++ b/olivertwist/ruleengine/engine.py
@@ -8,7 +8,7 @@ Created 15. Dec 2020 14:45
 from typing import List
 
 import olivertwist
-from olivertwist.config.model import Config
+from olivertwist.config.model import Config, Severity
 from olivertwist.manifest import Manifest
 from olivertwist.ruleengine.discovery import rules_in_package
 from olivertwist.ruleengine.result import Result
@@ -22,13 +22,23 @@ class RuleEngine:
     def __iter__(self):
         return iter(self.rules)
 
+    def __get_enabled_rules(all_rules: List[Rule], config: Config):
+        enabled_rules = []
+        for rule in all_rules:
+            if rule.id not in config.get_disabled_rule_ids():
+                rule_config = config.get_config_for_rule_id(rule.id)
+                if rule_config:
+                    rule.severity = rule_config.severity
+                else:
+                    rule.severity = Severity.ERROR
+                enabled_rules.append(rule)
+        return enabled_rules
+
     @classmethod
     def with_configured_rules(cls, config: Config) -> "RuleEngine":
         all_rules = rules_in_package(olivertwist)
-        rules = [
-            rule for rule in all_rules if rule.id not in config.get_disabled_rule_ids()
-        ]
-        return cls(rules)
+        enabled_rules = RuleEngine.__get_enabled_rules(all_rules, config)
+        return cls(enabled_rules)
 
     def run(self, manifest: Manifest) -> List[Result]:
         return [Result(rule, *rule.apply(manifest)) for rule in self.rules]

--- a/olivertwist/ruleengine/result.py
+++ b/olivertwist/ruleengine/result.py
@@ -7,6 +7,7 @@ Created 15. Dec 2020 17:09
 """
 from typing import List
 
+from olivertwist.config.model import Severity
 from olivertwist.manifest import Node
 from olivertwist.ruleengine.rule import Rule
 
@@ -18,5 +19,9 @@ class Result:
         self.failures = failures
 
     @property
-    def has_failures(self):
-        return bool(self.failures)
+    def has_errors(self):
+        return self.rule.severity is Severity.ERROR and bool(self.failures)
+
+    @property
+    def has_warnings(self):
+        return self.rule.severity is Severity.WARNING and bool(self.failures)

--- a/olivertwist/ruleengine/rule.py
+++ b/olivertwist/ruleengine/rule.py
@@ -7,6 +7,7 @@ Created 15. Dec 2020 14:31
 """
 from typing import Callable, List, Tuple
 
+from olivertwist.config.model import Severity
 from olivertwist.manifest import Manifest, Node
 
 
@@ -20,12 +21,23 @@ class Rule:
         self.id = id
         self.name = name
         self.func = func
+        self._severity = Severity.ERROR
 
     def __call__(self, *args, **kwargs):
         return self.apply(*args, **kwargs)
 
     def apply(self, manifest) -> Tuple[List[Node], List[Node]]:
         return self.func(manifest)
+
+    @property
+    def severity(self):
+        return self._severity
+
+    @severity.setter
+    def severity(self, severity: Severity):
+        if not isinstance(severity, Severity):
+            raise TypeError("severity must be an instance of Severity enum.")
+        self._severity = severity
 
 
 def rule(id, name):

--- a/tests/config/examples/no_version_config.yml
+++ b/tests/config/examples/no_version_config.yml
@@ -3,3 +3,6 @@ universal:
       enabled: false
     - id: no-disabled-models
       enabled: true
+    - id: no-orphaned-models
+      enabled: true
+      severity: warning

--- a/tests/reporter/test_adapter.py
+++ b/tests/reporter/test_adapter.py
@@ -1,12 +1,22 @@
+from typing import List
+
 from olivertwist.manifest import Node
 from olivertwist.metricengine.result import MetricResult
 from olivertwist.reporter.adapter import to_html_report
-from olivertwist.reporter.model import *
+from olivertwist.reporter.model import (
+    ReportSummary,
+    ReportModel,
+    ReportMetrics,
+    ReportRule,
+    ReportStatus,
+    Report,
+    MyEncoder,
+)
 from olivertwist.ruleengine.result import Result
 from olivertwist.ruleengine.rule import Rule
 
 expected_html_report: Report = Report(
-    ReportSummary(1, 0, 1),
+    ReportSummary(1, 0, 1, 1),
     [
         ReportModel(
             "model1",
@@ -21,7 +31,7 @@ expected_html_report: Report = Report(
                 ReportMetrics("pagerank", 0),
             ],
             [ReportRule("a-rule", "a rule name", ReportStatus.PASSED)],
-            ReportSummary(1, 0, 0),
+            ReportSummary(1, 0, 0, 0),
         ),
         ReportModel(
             "model2",
@@ -36,9 +46,13 @@ expected_html_report: Report = Report(
                 ReportMetrics("pagerank", 0),
             ],
             [
-                ReportRule("a-failed-rule", "a rule name", ReportStatus.ERRORED,)
+                ReportRule(
+                    "a-failed-rule",
+                    "a rule name",
+                    ReportStatus.ERRORED,
+                )
             ],
-            ReportSummary(0, 0, 1),
+            ReportSummary(0, 0, 1, 1),
         ),
     ],
 )
@@ -64,6 +78,6 @@ def test_should_convert_to_html_output():
 def test_json_serialisation():
     actual = MyEncoder().encode(expected_html_report)
 
-    expected_serialisation = """{"summary": {"passed": 1, "skipped": 0, "errored": 1}, "models": [{"model_key": "model1", "file_path": "", "model_name": "model1", "metrics": [{"name": "degree_centrality", "score": 0, "pretty_name": "Degree centrality"}, {"name": "in_degree_centrality", "score": 0, "pretty_name": "In degree centrality"}, {"name": "out_degree_centrality", "score": 0, "pretty_name": "Out degree centrality"}, {"name": "closeness_centrality", "score": 0, "pretty_name": "Closeness centrality"}, {"name": "betweenness_centrality", "score": 0, "pretty_name": "Betweenness centrality"}, {"name": "pagerank", "score": 0, "pretty_name": "Pagerank"}], "rules": [{"id": "a-rule", "name": "a rule name", "status": "passed"}], "summary": {"passed": 1, "skipped": 0, "errored": 0}}, {"model_key": "model2", "file_path": "", "model_name": "model2", "metrics": [{"name": "degree_centrality", "score": 0, "pretty_name": "Degree centrality"}, {"name": "in_degree_centrality", "score": 0, "pretty_name": "In degree centrality"}, {"name": "out_degree_centrality", "score": 0, "pretty_name": "Out degree centrality"}, {"name": "closeness_centrality", "score": 0, "pretty_name": "Closeness centrality"}, {"name": "betweenness_centrality", "score": 0, "pretty_name": "Betweenness centrality"}, {"name": "pagerank", "score": 0, "pretty_name": "Pagerank"}], "rules": [{"id": "a-failed-rule", "name": "a rule name", "status": "errored"}], "summary": {"passed": 0, "skipped": 0, "errored": 1}}]}"""
+    expected_serialisation = """{"summary": {"passed": 1, "skipped": 0, "errored": 1, "warned": 1}, "models": [{"model_key": "model1", "file_path": "", "model_name": "model1", "metrics": [{"name": "degree_centrality", "score": 0, "pretty_name": "Degree centrality"}, {"name": "in_degree_centrality", "score": 0, "pretty_name": "In degree centrality"}, {"name": "out_degree_centrality", "score": 0, "pretty_name": "Out degree centrality"}, {"name": "closeness_centrality", "score": 0, "pretty_name": "Closeness centrality"}, {"name": "betweenness_centrality", "score": 0, "pretty_name": "Betweenness centrality"}, {"name": "pagerank", "score": 0, "pretty_name": "Pagerank"}], "rules": [{"id": "a-rule", "name": "a rule name", "status": "passed"}], "summary": {"passed": 1, "skipped": 0, "errored": 0, "warned": 0}}, {"model_key": "model2", "file_path": "", "model_name": "model2", "metrics": [{"name": "degree_centrality", "score": 0, "pretty_name": "Degree centrality"}, {"name": "in_degree_centrality", "score": 0, "pretty_name": "In degree centrality"}, {"name": "out_degree_centrality", "score": 0, "pretty_name": "Out degree centrality"}, {"name": "closeness_centrality", "score": 0, "pretty_name": "Closeness centrality"}, {"name": "betweenness_centrality", "score": 0, "pretty_name": "Betweenness centrality"}, {"name": "pagerank", "score": 0, "pretty_name": "Pagerank"}], "rules": [{"id": "a-failed-rule", "name": "a rule name", "status": "errored"}], "summary": {"passed": 0, "skipped": 0, "errored": 1, "warned": 1}}]}"""
 
     assert actual == expected_serialisation

--- a/tests/ruleengine/test_engine.py
+++ b/tests/ruleengine/test_engine.py
@@ -5,7 +5,7 @@ Copyright (C) 2020, Auto Trader UK
 Created 15. Dec 2020 15:13
 
 """
-from olivertwist.config.model import Config, RuleConfig
+from olivertwist.config.model import Config, RuleConfig, Severity
 from olivertwist.manifest import Manifest, Node
 from olivertwist.ruleengine.engine import RuleEngine
 from olivertwist.ruleengine.result import Result
@@ -44,3 +44,25 @@ def test_rule_engine_factory_method_with_config_filtering_out_disabled_rules():
     )
 
     assert "no-rejoin-models" not in [rule.id for rule in engine.rules]
+
+
+def test_rule_engine_factory_method_with_config_setting_severity():
+    engine = RuleEngine.with_configured_rules(
+        config=Config(
+            universal=[
+                RuleConfig(
+                    id="no-rejoin-models", enabled=True, severity=Severity.ERROR
+                ),
+                RuleConfig(
+                    id="no-disabled-models", enabled=True, severity=Severity.WARNING
+                ),
+            ]
+        )
+    )
+
+    assert ("no-rejoin-models", Severity.ERROR) in [
+        (rule.id, rule.severity) for rule in engine.rules
+    ]
+    assert ("no-disabled-models", Severity.WARNING) in [
+        (rule.id, rule.severity) for rule in engine.rules
+    ]


### PR DESCRIPTION
Warnings will not cause a "🔀 Twisted!" response.

The config now looks like this:
```
    - id: no-rejoin-models
      enabled: true
      severity: error
```

and the report like this:
<img width="1411" alt="tmp" src="https://user-images.githubusercontent.com/61307/104515172-56afc480-55ea-11eb-92a4-b0b38e3a2829.png">