### PR TITLE
Load custom rules from directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ This will report any failures to the console, and also in HTML format in a direc
 olivertwist check manifest.json --browser
 ```
 
-Full options are available with:
+You can also tell Oliver to load and run your own custom rules using the `--add-rules-from` option. See [documentation for full details](https://olivertwi.st/custom_rules/).
 
+Full options are available with:
 
 ```shell
 olivertwist check --help

--- a/docs/custom_rules.md
+++ b/docs/custom_rules.md
@@ -1,0 +1,23 @@
+---
+title: Custom Rules
+description: Adding your own rules
+---
+
+You can load and run your own custom rules in Oliver Twist. This is achieved using the `--add-rules-from` option, which is repeatable, allowing you to load rules from multiple locations, e.g.
+
+```shell
+olivertwist check --add-rules-from=./custom_rules/ --add-rules-from=./more_rules/ manifest.json
+```
+
+The value you give should be to a directory containing Python source (`.py`) files that encode the logic for your rules. In order to be discovered and run by Oliver Twist, your rules must be instances of `olivertwist.ruleengine.rule.Rule`. This can be achieved by applying the `@rule` decorator to a plain function with the signature `(manifest: Manifest) -> (passes: List[Node], failures: List[Node])` e.g.:
+
+```python
+from olivertwist.ruleengine.rule import rule
+
+@rule(id="my-pointless-rule", name="Everything is allowed!")
+def pass_everything(manifest: Manifest) -> Tuple[List[Node], List[Node]]:
+    return list(manifest.nodes()), []
+
+```
+
+An important constraint here is that the `id` you specify should be unique and should not clash with any of the [pre-defined rules](./rules.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,22 +28,7 @@ This will report any failures to the console, and also in HTML format in a direc
 olivertwist check manifest.json --browser
 ```
 
-You can also tell Oliver to load and run your own custom rules using the `--add-rules-from` option:
-
-```shell
-olivertwist check --add-rules-from=./custom_rules_dir/ manifest.json
-```
-
-In order to be discovered and run, rules must be instances of `olivertwist.ruleengine.rule.Rule`. This can be achieved by instantiating an instance of the class directly, or by applying the `@rule` decorator to a plain function with the signature `(manifest: Manifest) -> (passes: List[Node], failures: List[Node])` e.g.:
-
-```python
-from olivertwist.ruleengine.rule import rule
-
-@rule(id="my-pointless-rule", name="Everything is allowed!")
-def pass_everything(manifest: Manifest) -> Tuple[List[Node], List[Node]]:
-    return list(manifest.nodes()), []
-
-```
+You can also tell Oliver to load and run your own custom rules using the `--add-rules-from` option. See [Custom Rules](./custom_rules.md) for full details.
 
 Full options are available with:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,23 @@ This will report any failures to the console, and also in HTML format in a direc
 olivertwist check manifest.json --browser
 ```
 
+You can also tell Oliver to load and run your own custom rules using the `--add-rules-from` option:
+
+```shell
+olivertwist check --add-rules-from=./custom_rules_dir/ manifest.json
+```
+
+In order to be discovered and run, rules must be instances of `olivertwist.ruleengine.rule.Rule`. This can be achieved by instantiating an instance of the class directly, or by applying the `@rule` decorator to a plain function with the signature `(manifest: Manifest) -> (passes: List[Node], failures: List[Node])` e.g.:
+
+```python
+from olivertwist.ruleengine.rule import rule
+
+@rule(id="my-pointless-rule", name="Everything is allowed!")
+def pass_everything(manifest: Manifest) -> Tuple[List[Node], List[Node]]:
+    return list(manifest.nodes()), []
+
+```
+
 Full options are available with:
 
 ```shell

--- a/olivertwist/config/configurator.py
+++ b/olivertwist/config/configurator.py
@@ -11,13 +11,13 @@ from PyInquirer import prompt
 
 import olivertwist
 from olivertwist.config.model import Config, RuleConfig
-from olivertwist.ruleengine.discovery import rules_in_package
+from olivertwist.ruleengine.discovery import rules_in_path
 
 
 class Configurator:
     @classmethod
     def update(cls, config: Config) -> Config:
-        all_rules = rules_in_package(olivertwist)
+        all_rules = rules_in_path(olivertwist.__path__[0])
         disabled = config.get_disabled_rule_ids()
         choices = [
             {

--- a/olivertwist/config/io.py
+++ b/olivertwist/config/io.py
@@ -40,7 +40,7 @@ class ConfigIO:
             if cls.DEFAULT_CONFIG_FILE_PATH.exists():
                 config = cls.__parse(cls.DEFAULT_CONFIG_FILE_PATH)
             else:
-                return Config(universal=[])
+                return Config.empty()
         else:
             config = cls.__parse(path)
 

--- a/olivertwist/config/model.py
+++ b/olivertwist/config/model.py
@@ -29,6 +29,10 @@ class RuleConfig(JsonSchemaMixin):
 class Config(JsonSchemaMixin):
     universal: List[RuleConfig]
 
+    @classmethod
+    def empty(cls):
+        return cls(universal=[])
+
     def get_disabled_rule_ids(self) -> List[str]:
         return [r.id for r in self.universal if r.enabled is False]
 

--- a/olivertwist/ruleengine/discovery.py
+++ b/olivertwist/ruleengine/discovery.py
@@ -5,23 +5,34 @@ Copyright (C) 2021, Auto Trader UK
 Created 08. Jan 2021 18:01
 
 """
-import pkgutil
-from importlib import import_module
+import importlib
+import os
+from pathlib import Path
+from typing import List, Union
 
 from olivertwist.ruleengine.rule import Rule
 
 
-def rules_in_package(package):
-    rules = []
-    for info in pkgutil.walk_packages(
-        path=package.__path__, prefix=package.__name__ + "."
-    ):
-        if "__" in info.name:
-            continue
+def rules_in_path(path: Union[Path, str]) -> List[Rule]:
+    if isinstance(path, str):
+        path = Path(path)
 
-        mod = import_module(info.name)
-        for obj in mod.__dict__.values():
-            if isinstance(obj, Rule):
-                rules.append(obj)
+    rules = []
+    for root, dirs, files in os.walk(path):
+        rule_files = [Path(root) / f for f in files if Path(f).suffix == ".py"]
+        for p in rule_files:
+            mod_name = f"ot_custom_rule_file_{hash(p)}"
+            loader = importlib.machinery.SourceFileLoader(mod_name, str(p))
+            spec = importlib.util.spec_from_loader(mod_name, loader)
+            mod = importlib.util.module_from_spec(spec)
+            loader.exec_module(mod)
+            for obj in mod.__dict__.values():
+                if isinstance(obj, Rule):
+                    rules.append(obj)
 
     return rules
+
+
+def _might_contain_rules(path: Union[Path, str]) -> bool:
+    p = Path(path)
+    return p.suffix == ".py"

--- a/olivertwist/ruleengine/engine.py
+++ b/olivertwist/ruleengine/engine.py
@@ -37,6 +37,10 @@ class RuleEngine:
         enabled_rules = RuleEngine.__get_enabled_rules(all_rules, config)
         return cls(enabled_rules)
 
+    def extend(self, other: "RuleEngine") -> None:
+        """Mutate self by extending with the rules in `other`."""
+        self.rules.extend(other.rules)
+
     def run(self, manifest: Manifest) -> List[Result]:
         return [Result(rule, *rule.apply(manifest)) for rule in self.rules]
 

--- a/tests/ruleengine/test_engine.py
+++ b/tests/ruleengine/test_engine.py
@@ -35,6 +35,19 @@ def test_rule_engine_returns_results_for_rule_set(empty_raw_manifest):
     assert isinstance(results[0], Result)
 
 
+def test_rule_engine_extend():
+    nodes = [Node({})]
+    engine_1 = RuleEngine([Rule("test-1", "this always fails!", lambda m: ([], nodes))])
+    engine_2 = RuleEngine(
+        [Rule("test-2", "this always succeeds!", lambda m: (nodes, []))]
+    )
+
+    engine_1.extend(engine_2)
+
+    assert len(engine_1) == 2
+    assert ["test-1", "test-2"] == [r.id for r in engine_1]
+
+
 def test_rule_engine_factory_method():
     engine = RuleEngine.with_configured_rules(Config(universal=[]))
 

--- a/tests/ruleengine/test_engine.py
+++ b/tests/ruleengine/test_engine.py
@@ -26,7 +26,7 @@ def test_rule_engine_factory_method():
     engine = RuleEngine.with_configured_rules(Config(universal=[]))
 
     count = 0
-    for count, rule in enumerate(engine):
+    for rule in engine:
         assert isinstance(rule, Rule)
         count += 1
 

--- a/tests/ruleengine/test_engine.py
+++ b/tests/ruleengine/test_engine.py
@@ -5,11 +5,24 @@ Copyright (C) 2020, Auto Trader UK
 Created 15. Dec 2020 15:13
 
 """
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+
+import pytest
+
 from olivertwist.config.model import Config, RuleConfig, Severity
 from olivertwist.manifest import Manifest, Node
 from olivertwist.ruleengine.engine import RuleEngine
 from olivertwist.ruleengine.result import Result
 from olivertwist.ruleengine.rule import Rule
+
+
+@pytest.fixture(scope="module")
+def custom_rule_path():
+    temp_dir = mkdtemp()
+    yield Path(temp_dir)
+    rmtree(temp_dir)
 
 
 def test_rule_engine_returns_results_for_rule_set(empty_raw_manifest):
@@ -43,7 +56,7 @@ def test_rule_engine_factory_method_with_config_filtering_out_disabled_rules():
         )
     )
 
-    assert "no-rejoin-models" not in [rule.id for rule in engine.rules]
+    assert "no-rejoin-models" not in [rule.id for rule in engine]
 
 
 def test_rule_engine_factory_method_with_config_setting_severity():
@@ -61,8 +74,23 @@ def test_rule_engine_factory_method_with_config_setting_severity():
     )
 
     assert ("no-rejoin-models", Severity.ERROR) in [
-        (rule.id, rule.severity) for rule in engine.rules
+        (rule.id, rule.severity) for rule in engine
     ]
     assert ("no-disabled-models", Severity.WARNING) in [
-        (rule.id, rule.severity) for rule in engine.rules
+        (rule.id, rule.severity) for rule in engine
     ]
+
+
+def test_rule_engine_factory_from_arbitrary_directory(custom_rule_path):
+    with open(custom_rule_path / "my_rule.py", "w") as fh:
+        fh.write("from olivertwist.ruleengine.rule import Rule\n\n")
+        fh.write(
+            'r = Rule("my-custom-rule", "Some custom rule", lambda _: (passes, failures))'
+        )
+
+    engine = RuleEngine.with_configured_rules(
+        config=Config(universal=[]), directory=custom_rule_path
+    )
+
+    assert len(engine) == 1
+    assert "my-custom-rule" in (rule.id for rule in engine)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,9 +5,14 @@ Copyright (C) 2021, Auto Trader UK
 Created 21. Jan 2021 19:37
 
 """
+from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from olivertwist.config.configurator import Configurator
+from olivertwist.config.io import ConfigIO
+from olivertwist.config.model import Config, RuleConfig
 from olivertwist.main import main
 
 
@@ -35,3 +40,46 @@ def test_check_with_non_existent_config():
 
         assert result.exit_code != 0
         assert "Invalid value for '--config'" in result.output
+
+
+@patch.object(Configurator, "update", return_value=Config.empty())
+def test_config_outputs_file(_):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["config"])
+
+        assert result.exit_code == 0
+        config_path = Path("olivertwist.yml")
+        assert config_path.exists
+        assert result.output == f"Created/updated config in {config_path}\n"
+
+
+@patch.object(Configurator, "update", return_value=Config.empty())
+def test_config_with_config_file_not_existing(_):
+    runner = CliRunner()
+    config_path = Path("twisted.yml")
+    with runner.isolated_filesystem():
+        assert not config_path.exists()
+
+        result = runner.invoke(main, ["--debug", "config", f"--config={config_path}"])
+
+        assert result.exit_code == 0
+        assert result.output == f"Created/updated config in {config_path}\n"
+        assert config_path.exists()
+
+
+@patch.object(Configurator, "update", return_value=Config.empty())
+def test_config_with_config_file_existing(_):
+    runner = CliRunner()
+    config_path = "twisted.yml"
+    dummy_rule_config = RuleConfig("a", enabled=False)
+    with runner.isolated_filesystem():
+        ConfigIO.write(Config(universal=[dummy_rule_config]), config_path)
+
+        result = runner.invoke(main, ["config", "--config=twisted.yml"])
+
+        assert result.exit_code == 0
+        assert result.output == f"Created/updated config in {config_path}\n"
+        assert (
+            ConfigIO.read(config_path) == Config.empty()
+        ), "existing config not overwritten"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,8 @@ Copyright (C) 2021, Auto Trader UK
 Created 21. Jan 2021 19:37
 
 """
+import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -40,6 +42,32 @@ def test_check_with_non_existent_config():
 
         assert result.exit_code != 0
         assert "Invalid value for '--config'" in result.output
+
+
+def test_check_with_additional_rules_directories(empty_raw_manifest):
+    runner = CliRunner()
+    manifest_json = "manifest.json"
+    rule_dir_1 = "my_rules"
+    rule_dir_2 = "more_rules"
+    with runner.isolated_filesystem():
+        with open(manifest_json, "w") as fh:
+            json.dump(empty_raw_manifest, fh)
+
+        os.mkdir(rule_dir_1)
+        os.mkdir(rule_dir_2)
+
+        result = runner.invoke(
+            main,
+            [
+                "--debug",
+                "check",
+                f"--add-rules-from={rule_dir_1}",
+                f"--add-rules-from={rule_dir_2}",
+                manifest_json,
+            ],
+        )
+
+        assert result.exit_code == 0
 
 
 @patch.object(Configurator, "update", return_value=Config.empty())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Some CLI test
+
+Copyright (C) 2021, Auto Trader UK
+Created 21. Jan 2021 19:37
+
+"""
+
+from click.testing import CliRunner
+
+from olivertwist.main import main
+
+
+def test_check_non_existent_manifest():
+    runner = CliRunner()
+    missing_manifest_json = "manifest.json"
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["check", missing_manifest_json])
+
+        assert result.exit_code != 0
+        assert (
+            f"Could not open file: {missing_manifest_json}: No such file or directory"
+            in result.output
+        )
+
+
+def test_check_with_non_existent_config():
+    runner = CliRunner()
+    manifest_json = "manifest.json"
+    with runner.isolated_filesystem():
+        with open(manifest_json, "w") as fh:
+            fh.write("{}")
+
+        result = runner.invoke(main, ["check", "--config=twisted.yml", manifest_json])
+
+        assert result.exit_code != 0
+        assert "Invalid value for '--config'" in result.output


### PR DESCRIPTION
Add an option to load additional custom rules from an arbitrary directory.

Discovered rules must be an instance of `olivertwist.ruleengine.rule.Rule`. This can be achieved by instantiating an instance of the class, or applying the `@rule` decorator (`olivertwist.ruleengine.rule.rule`) to a plain function with the signature `(manifest: Manifest) -> (passes: List[Node], failures: List[Node])`

Closes #27 